### PR TITLE
Docker tweaks

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.bloop/
+metals.sbt
+.metals/

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target
 .bloop/
 .g8/
 .metals/
+metals.sbt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,16 @@
 FROM hseeberger/scala-sbt:8u242_1.3.7_2.12.10
 
 WORKDIR /opt/book-api
-
-ADD . /opt/book-api
-
 EXPOSE 9000
 
+# add build and project so that dependencies can be downloaded -- this will only rerun if the dependencies change,
+# but not if the code changes
+ADD ./project   ./project
+ADD ./build.sbt ./build.sbt
+RUN sbt update
+
+# add everything else
+ADD . .
+
 ENTRYPOINT ["sbt"]
+CMD ["run"]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -3,9 +3,12 @@
 # Default database configuration using MySQL database engine
 # Connect to scalatestdb as testuser
 slick.dbs.default.profile = "slick.jdbc.MySQLProfile$"
-slick.dbs.default.db.driver = "com.mysql.jdbc.Driver"
-slick.dbs.default.db.url = "jdbc:mysql://db:3306/scalabooksdb?useSSL=false"
-slick.dbs.default.db.user = "username"
-slick.dbs.default.db.password="password"
+slick.dbs.default.db.driver = "com.mysql.cj.jdbc.Driver"
+slick.dbs.default.db.host = db
+slick.dbs.default.db.port = 3306
+slick.dbs.default.db.database = scalabooksdb
+slick.dbs.default.db.url = "jdbc:mysql://"${slick.dbs.default.db.host}":"${slick.dbs.default.db.port}"/"${slick.dbs.default.db.database}"?useSSL=false"
+slick.dbs.default.db.user = "root"
+slick.dbs.default.db.password = "root"
 
-applyEvolutions.default=true
+play.evolutions.db.default.autoApply = true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,8 @@
 version: "3.7"
 
+volumes:
+  sbtuser:
+
 services:
   book_server: #container name
     build:
@@ -7,21 +10,16 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./:/opt/book-api
-    ports: 
+      - sbtuser:/home/sbtuser
+    ports:
       - 9000:9000
-    environment: 
-      - DATABASE_URL=jdbc:mysql://localhost/scalabooksdb?useSSL=false
-    command: 
+    command:
       - run
-    depends_on: 
+    depends_on:
       - db
-  
+
   db:
     image: mysql:5.7
-    ports:
-      - "32000:3306"
     environment:
       MYSQL_DATABASE: scalabooksdb
       MYSQL_ROOT_PASSWORD: root
-      MYSQL_PASSWORD: password
-      MYSQL_USERNAME: username


### PR DESCRIPTION
Dockerfile:
- to improve caching, first add dependencies then add remaining code
- add default CMD and some comments for clarity

application.conf:
- switch db credentials to root
- construct the db url from port, host, and database
  - can create separate defaults and overrides for each one with ${?DB_PORT}, ${?DB_HOST}, and ${?DB_DATABASE}
- update deprecated configs
  - use play.evolutions.db.default.autoApply instead of applyEvolutions.default
  - replace driver

docker-compose.yml
- remove MYSQL_USER and MYSQL_PASSWORD envvars from db, just use root for simplicity
  - the mysql image rejects connections for the MYSQL_USER for some reason
- remove unnecessary port mapping on db
- add volume to book_server to cache dependencies

update .dockerignore and .gitignore to ignore VS Code files